### PR TITLE
add docker container and automated build for quick demo or usage

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -1,0 +1,50 @@
+name: Build Deploy Containers
+
+on:
+
+  # Publish packages on release
+  release:
+    types: [published]
+
+  pull_request: []
+
+  # On push to main we build and deploy images
+  push:
+    branches:
+    - main
+
+jobs:
+  build:
+    permissions:
+      packages: write
+
+    env:
+      container: ghcr.io/magic-sph/magic
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build Container
+      run: docker build -t ${{ env.container }} .
+
+    - name: GHCR Login
+      if: (github.event_name != 'pull_request')
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Tag and Push Release Image
+      if: (github.event_name == 'release')
+      run: |
+        tag=${GITHUB_REF#refs/tags/}
+        echo "Tagging and releasing ${{ env.container }}:${tag}"
+        docker tag ${{ env.container }}:latest ${{ env.container }}:${tag}
+        docker push ${{ env.container }}:${tag}
+
+    - name: Deploy
+      if: (github.event_name != 'pull_request')
+      run: docker push ${{ env.container }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:22.04
+
+# This is a demo container for testing magic!
+# docker build -t magic .
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    fftw3-dev fftw3 \
+    gfortran \
+    git \
+    libmpich-dev \
+    python3 \
+    python3-matplotlib \
+    python3-f2py \
+    wget && \
+    ln -s /usr/bin/python3 /usr/bin/python
+        
+WORKDIR /code
+COPY . /code
+
+# install SHTns with fft, then build magic and run (and build) samples
+RUN /bin/bash -c ". sourceme.sh && \
+    cd ./bin && \
+    CC=gcc ./install-shtns.sh && \
+    cd ../ && mkdir -p ./build && cd ./build && \
+    FC=mpif90 cmake .. -DUSE_SHTNS=yes && make && \
+    cd ../samples && \
+   ./magic_wizard.py --use-mpi --nranks 4 --mpicmd mpiexec"
+
+ENTRYPOINT ["/code/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,46 @@
 
 # Quickly start using MagIC
 
+## Docker
+
+We provide a [Dockerfile](Dockerfile) for a quick environment you can use magic! It 
+comes with an ubuntu base, mpich (mpif90), and installs SHTns.
+
+```bash
+$ docker build -t magic .
+```
+
+Note that we build samples and run them (for testing) so the build takes a bit of time.
+When it's done, let's now try interacting with the container. Note that the [entrypoint.sh](entrypoint.sh) script sources [sourceme.sh](sourceme.sh)
+before executing your command, and thus will ensure the environment is ready.
+
+```bash
+# Ensure that the file is sourced
+$ docker run --rm -it magic env | grep MAGIC_HOME
+```
+```console
+MAGIC_HOME = </code>
+MAGIC_HOME=/code
+```
+
+To shell inside and interact:
+
+```bash
+$ docker run -it magic bash
+```
+
+And the environment should be ready, e.g.,
+
+```bash
+cd /code/samples
+./magic_wizard.py --use-mpi --nranks 4 --mpicmd mpiexec
+```
+
+And that's it! This container is also available via an automated build `ghcr.io/magic-sph/magic` if you want to
+pull it directly. For a customized or local install, continue to the next section.
+
+## Local Install
+
 ### 1) In order to check out the code, use the command
 
 ```sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. /code/sourceme.sh
+
+exec $@


### PR DESCRIPTION
This is a container and automated build that will make it easy to demo / quickly try out magic! I was able to run the full suite under samples in the container.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>