### PR TITLE
Correct the centrifugal buoyancy term

### DIFF
--- a/src/get_nl.f90
+++ b/src/get_nl.f90
@@ -366,9 +366,11 @@ contains
             !   !-- neglect pressure contribution
             !   !& + polind*DissNb*oek*opressure0(nR)*this%pc(:,nPhi) )
             !else
-            this%CAr(:,nPhi) = -dilution_fac*r(nR)*sinTheta(:)**4*ra*opr* &
+            ! Pr*Di/Ra*r^3*sin(theta)^2*T
+            this%CAr(:,nPhi) = -dilution_fac*r(nR)**3*sinTheta(:)**2*ra*opr* &
             &                       this%sc(:,nPhi)
-            this%CAt(:,nPhi) = -dilution_fac*r(nR)*sinTheta(:)**3*cosTheta(:)*ra*opr* &
+            ! Pr*Di/Ra*sin(theta)^2*cos(theta)*T
+            this%CAt(:,nPhi) = -dilution_fac*sinTheta(:)**2*cosTheta(:)*ra*opr* &
             &                       this%sc(:,nPhi)
             !end if
          end if ! centrifuge


### PR DESCRIPTION
The centrifugal buoyancy in a rotating reference frame, commonly defined as:
beta*DeltaT*Omega^2*d^4*/nu^2*r*sin(theta)[-sin(theta),-cos(theta),0] 
is corrected according to the scaling [r^2;sin(theta)/r,sin(theta)/r] described in the documentation.
The factor before Di*RaE/Pr returns beta*DeltaT*Omega^2*d^4*/nu^2.

The implementation before could not show according result in benchmark test. 